### PR TITLE
Fix the logic for crates/barrels without an item

### DIFF
--- a/src/enemy/crate.monkey
+++ b/src/enemy/crate.monkey
@@ -190,8 +190,7 @@ Class Crate Extends Enemy
         If Level.creatingMap Then replayConsistencyChannel = -1
 
         Local itemRoll := Util.RndIntRange(0, 100, False, replayConsistencyChannel)
-        If (Self.crateType = Crate.TYPE_BARREL And itemRoll <= 30) Or
-           itemRoll <= 40
+        If itemRoll <= 30 Or (Self.crateType <> Crate.TYPE_BARREL And itemRoll <= 40)
             Self.beEmpty = True
         Else If Not Self.beEmpty
             Self.contents = Crate.SelectItem(controller_game.currentLevel)
@@ -238,12 +237,16 @@ Class Crate Extends Enemy
             Return
         End If
 
-        If coinsRoll > 98
+        If coinsRoll <= 98
             Self.emptyCoins = 30
             If Player.DoesAnyPlayerHaveItemOfType(ItemType.RingOfLuck)
                 Self.emptyCoins = 50
             End If
+
+            Return
         End If
+
+        Self.emptyCoins = 50
     End Method
 
     Method DetermineContents: Void()

--- a/src/necrodancer.buildv87a/glfw3/main.cpp
+++ b/src/necrodancer.buildv87a/glfw3/main.cpp
@@ -41867,7 +41867,7 @@ void c_Crate::p_DecideIfStayingEmpty(){
 		t_replayConsistencyChannel=-1;
 	}
 	int t_itemRoll=c_Util::m_RndIntRange(0,100,false,t_replayConsistencyChannel);
-	if(this->m_crateType==1 && t_itemRoll<=30 || t_itemRoll<=40){
+	if(t_itemRoll<=30 || (this->m_crateType!=1 && t_itemRoll<=40)){
 		this->m_beEmpty=true;
 	}else{
 		if(!this->m_beEmpty){
@@ -41904,11 +41904,15 @@ void c_Crate::p_DecideIfStayingEmpty(){
 		}
 		return;
 	}
-	if(t_coinsRoll>98){
+	if(t_coinsRoll<=98){
 		this->m_emptyCoins=30;
 		if(c_Player::m_DoesAnyPlayerHaveItemOfType(String(L"ring_luck",9),false)){
 			this->m_emptyCoins=50;
 		}
+		return;
+	}
+	if(t_coinsRoll>98){
+		this->m_emptyCoins=50;
 	}
 }
 void c_Crate::p_DetermineContents(){


### PR DESCRIPTION
The probability of barrels not having an item was 41/101, when it should be
31/101.

Barrels and crates without an item had a 23/101 chance to be completely empty,
and a 2/101 chance to hold 30 coins (50 with ring of luck). It should instead
be 23/101 chance to hold 30 coins (50 with ring of luck), and 2/101 to hold 50
coins.

With those modifications, the expected amount of gold is 43809 per 10000
crates, and 33124 per 10000 barrels. I tested in ND and got 44070 and 32930
respectively, confirming those are the correct probabilities (or very close).